### PR TITLE
Add a HydePHP subsystem for blog posts

### DIFF
--- a/_posts/hello-world.md
+++ b/_posts/hello-world.md
@@ -1,0 +1,9 @@
+---
+title: 'My New Post'
+description: 'A short description used in previews and SEO'
+category: blog
+author: default
+date: '2024-04-06 07:15'
+---
+
+## Write something awesome.

--- a/app/Http/Controllers/HydeController.php
+++ b/app/Http/Controllers/HydeController.php
@@ -3,8 +3,15 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\View\View;
+use Hyde\Pages\MarkdownPost;
 
 class HydeController extends Controller
 {
-    //
+    public function posts(): View
+    {
+        return view('hyde::components.blog-post-feed', [
+           'posts' => MarkdownPost::getLatestPosts(),
+        ]);
+    }
 }

--- a/app/Http/Controllers/HydeController.php
+++ b/app/Http/Controllers/HydeController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class HydeController extends Controller
+{
+    //
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -65,5 +65,6 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'hyde' => \App\Http\Middleware\BootHydeKernelMiddleware::class,
     ];
 }

--- a/app/Http/Middleware/BootHydeKernelMiddleware.php
+++ b/app/Http/Middleware/BootHydeKernelMiddleware.php
@@ -15,6 +15,9 @@ class BootHydeKernelMiddleware
      */
     public function handle(Request $request, Closure $next): Response
     {
+        // Register the Hyde service provider
+        app()->register(\App\Providers\HydeServiceProvider::class);
+
         return $next($request);
     }
 }

--- a/app/Http/Middleware/BootHydeKernelMiddleware.php
+++ b/app/Http/Middleware/BootHydeKernelMiddleware.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class BootHydeKernelMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/BootHydeKernelMiddleware.php
+++ b/app/Http/Middleware/BootHydeKernelMiddleware.php
@@ -6,6 +6,9 @@ use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * This middleware boots the Hyde kernel for routes that require it.
+ */
 class BootHydeKernelMiddleware
 {
     /**

--- a/app/Providers/HydeServiceProvider.php
+++ b/app/Providers/HydeServiceProvider.php
@@ -13,7 +13,10 @@ class HydeServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton('hyde', function (): HydeKernel {
-            return new HydeKernel(base_path());
+            $kernel = new HydeKernel(base_path());
+            HydeKernel::setInstance($kernel);
+
+            return $kernel;
         });
     }
 

--- a/app/Providers/HydeServiceProvider.php
+++ b/app/Providers/HydeServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class HydeServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/app/Providers/HydeServiceProvider.php
+++ b/app/Providers/HydeServiceProvider.php
@@ -25,6 +25,6 @@ class HydeServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        app('hyde')->boot();
     }
 }

--- a/app/Providers/HydeServiceProvider.php
+++ b/app/Providers/HydeServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Hyde\Foundation\HydeKernel;
 use Illuminate\Support\ServiceProvider;
 
 class HydeServiceProvider extends ServiceProvider
@@ -11,7 +12,9 @@ class HydeServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton('hyde', function (): HydeKernel {
+            return new HydeKernel(base_path());
+        });
     }
 
     /**

--- a/app/Providers/HydeServiceProvider.php
+++ b/app/Providers/HydeServiceProvider.php
@@ -12,6 +12,7 @@ class HydeServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
+        // Register the Hyde kernel as a singleton
         $this->app->singleton('hyde', function (): HydeKernel {
             $kernel = new HydeKernel(base_path());
             HydeKernel::setInstance($kernel);

--- a/app/Providers/HydeServiceProvider.php
+++ b/app/Providers/HydeServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Hyde\Foundation\HydeKernel;
+use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\ServiceProvider;
 
 class HydeServiceProvider extends ServiceProvider
@@ -19,6 +20,11 @@ class HydeServiceProvider extends ServiceProvider
 
             return $kernel;
         });
+
+        // Register facade aliases to use in the views
+        $loader = AliasLoader::getInstance();
+        $loader->alias('Hyde', \Hyde\Hyde::class);
+        $loader->alias('MarkdownPost', \Hyde\Pages\MarkdownPost::class);
 
         // Define the view hint path for the Hyde package
         $this->loadViewsFrom(base_path('vendor/hyde/framework/resources/views'), 'hyde');

--- a/app/Providers/HydeServiceProvider.php
+++ b/app/Providers/HydeServiceProvider.php
@@ -19,6 +19,9 @@ class HydeServiceProvider extends ServiceProvider
 
             return $kernel;
         });
+
+        // Define the view hint path for the Hyde package
+        $this->loadViewsFrom(base_path('vendor/hyde/framework/resources/views'), 'hyde');
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.2",
+        "hyde/framework": "^1.5",
         "laravel/breeze": "^1.28",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f7f77830fbdbf063f73607737df40013",
+    "content-hash": "11406533f0c38a17e83d7741d9f0cca1",
     "packages": [
         {
             "name": "brick/math",
@@ -1044,6 +1044,66 @@
                 }
             ],
             "time": "2023-12-03T19:50:20+00:00"
+        },
+        {
+            "name": "hyde/framework",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hydephp/framework.git",
+                "reference": "4448c98199fd135f9c1b17f47e46e12378ff133e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hydephp/framework/zipball/4448c98199fd135f9c1b17f47e46e12378ff133e",
+                "reference": "4448c98199fd135f9c1b17f47e46e12378ff133e",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^10.0",
+                "illuminate/view": "^10.0",
+                "league/commonmark": "^2.2",
+                "php": "^8.1",
+                "spatie/yaml-front-matter": "^2.0.7",
+                "symfony/yaml": "^6.0",
+                "torchlight/torchlight-commonmark": "^0.5.5"
+            },
+            "suggest": {
+                "ext-simplexml": "Required to generate sitemaps and RSS feeds.",
+                "hyde/hyde": "The Framework package contains the Hyde Core. To create your site you should use the Hyde/Hyde project.",
+                "laravel-zero/framework": "^10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Hyde\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Caen De Silva",
+                    "email": "caen@desilva.se"
+                }
+            ],
+            "description": "The HydePHP Framework",
+            "support": {
+                "issues": "https://github.com/hydephp/framework/issues",
+                "source": "https://github.com/hydephp/framework/tree/v1.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.buymeacoffee.com/caen",
+                    "type": "custom"
+                }
+            ],
+            "time": "2024-02-13T11:03:16+00:00"
         },
         {
             "name": "laravel/breeze",
@@ -3245,6 +3305,68 @@
                 }
             ],
             "time": "2023-11-08T05:53:05+00:00"
+        },
+        {
+            "name": "spatie/yaml-front-matter",
+            "version": "2.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/yaml-front-matter.git",
+                "reference": "f2f1f749a405fafc9d6337067c92c062d51a581c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/yaml-front-matter/zipball/f2f1f749a405fafc9d6337067c92c062d51a581c",
+                "reference": "f2f1f749a405fafc9d6337067c92c062d51a581c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0|^8.0",
+                "symfony/yaml": "^3.0|^4.0|^5.0|^6.0|^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\YamlFrontMatter\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A to the point yaml front matter parser",
+            "homepage": "https://github.com/sebastiandedeyne/yaml-front-matter",
+            "keywords": [
+                "front matter",
+                "jekyll",
+                "spatie",
+                "yaml"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/yaml-front-matter/tree/2.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-04T10:02:52+00:00"
         },
         {
             "name": "symfony/console",
@@ -5504,6 +5626,78 @@
             "time": "2024-01-23T14:53:30+00:00"
         },
         {
+            "name": "symfony/yaml",
+            "version": "v6.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "d75715985f0f94f978e3a8fa42533e10db921b90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d75715985f0f94f978e3a8fa42533e10db921b90",
+                "reference": "d75715985f0f94f978e3a8fa42533e10db921b90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<5.4"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v6.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-23T14:51:35+00:00"
+        },
+        {
             "name": "tijsverkoyen/css-to-inline-styles",
             "version": "v2.2.7",
             "source": {
@@ -5555,6 +5749,61 @@
                 "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/v2.2.7"
             },
             "time": "2023-12-08T13:03:43+00:00"
+        },
+        {
+            "name": "torchlight/torchlight-commonmark",
+            "version": "v0.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/torchlight-api/torchlight-commonmark-php.git",
+                "reference": "eb618ae6187090126a9ef881ccaf9c315d49c99b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/torchlight-api/torchlight-commonmark-php/zipball/eb618ae6187090126a9ef881ccaf9c315d49c99b",
+                "reference": "eb618ae6187090126a9ef881ccaf9c315d49c99b",
+                "shasum": ""
+            },
+            "require": {
+                "league/commonmark": "^1.5|^2.0",
+                "php": "^7.2|^8.0",
+                "torchlight/torchlight-laravel": "^0.5.10"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3.3",
+                "orchestra/testbench": "^5.0|^6.0",
+                "phpunit/phpunit": "^8.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Torchlight\\Commonmark\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Francis",
+                    "email": "aaron@hammerstone.dev"
+                }
+            ],
+            "description": "A Commonmark extension for Torchlight, the syntax highlighting API.",
+            "homepage": "https://torchlight.dev",
+            "keywords": [
+                "Code highlighting",
+                "commonmark",
+                "laravel",
+                "markdown",
+                "syntax highlighting"
+            ],
+            "support": {
+                "issues": "https://github.com/torchlight-api/torchlight-commonmark-php/issues",
+                "source": "https://github.com/torchlight-api/torchlight-commonmark-php/tree/v0.5.5"
+            },
+            "time": "2022-02-23T17:09:44+00:00"
         },
         {
             "name": "torchlight/torchlight-laravel",
@@ -8941,78 +9190,6 @@
                 }
             ],
             "time": "2024-01-12T13:14:58+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v6.4.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "d75715985f0f94f978e3a8fa42533e10db921b90"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/d75715985f0f94f978e3a8fa42533e10db921b90",
-                "reference": "d75715985f0f94f978e3a8fa42533e10db921b90",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "symfony/console": "<5.4"
-            },
-            "require-dev": {
-                "symfony/console": "^5.4|^6.0|^7.0"
-            },
-            "bin": [
-                "Resources/bin/yaml-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Loads and dumps YAML files",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.3"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-01-23T14:51:35+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",

--- a/resources/views/vendor/hyde/components/blog-post-feed.blade.php
+++ b/resources/views/vendor/hyde/components/blog-post-feed.blade.php
@@ -1,0 +1,3 @@
+@foreach($posts ?? MarkdownPost::getLatestPosts() as $post)
+    @include('hyde::components.article-excerpt')
+@endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\AnalyticsController;
 use App\Http\Controllers\MarkdownViewController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\WindowlightController;
+use App\Http\Controllers\HydeController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -34,7 +35,7 @@ Route::middleware('auth')->group(function () {
 });
 
 Route::middleware('hyde')->group(function () {
-    //
+    Route::get('/posts', [HydeController::class, 'posts'])->name('posts');
 });
 
 require __DIR__.'/auth.php';

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,4 +33,8 @@ Route::middleware('auth')->group(function () {
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
 
+Route::middleware('hyde')->group(function () {
+    //
+});
+
 require __DIR__.'/auth.php';


### PR DESCRIPTION
Adds a modular implementation of [HydePHP](https://hydephp.com/?ref=Windowlight) to get rich blog posts. It's enabled using a middleware on a route group to only affect the pages that need it.